### PR TITLE
Refactor: Restrict API to localhost and remove enable/disable toggle

### DIFF
--- a/src/struct-system.go
+++ b/src/struct-system.go
@@ -271,7 +271,6 @@ type Notification struct {
 
 // SettingsStruct : Content of settings.json
 type SettingsStruct struct {
-	API                   bool     `json:"api"`
 	AuthenticationAPI     bool     `json:"authentication.api"`
 	AuthenticationM3U     bool     `json:"authentication.m3u"`
 	AuthenticationPMS     bool     `json:"authentication.pms"`

--- a/src/system.go
+++ b/src/system.go
@@ -103,7 +103,6 @@ func loadSettings() (settings SettingsStruct, err error) {
 	dataMap["m3u"] = make(map[string]any)
 	dataMap["hdhr"] = make(map[string]any)
 
-	defaults["api"] = false
 	defaults["authentication.api"] = false
 	defaults["authentication.m3u"] = false
 	defaults["authentication.pms"] = false


### PR DESCRIPTION
This commit ensures the API endpoints under /api/ are:
1. Restricted to localhost access only. Requests from non-loopback addresses will receive a 403 Forbidden error.
2. Always functionally available. The previous setting `Settings.API` used to toggle the API's availability has been removed from the codebase (struct definitions, settings defaults, and the check in the API handler).

The main web UI remains externally accessible as per its default behavior.

Changes include:
- Ensured localhost restriction logic is in place in `API()` in `src/webserver.go`.
- Removed the `if !Settings.API` check from `API()` in `src/webserver.go`.
- Removed the `API` field from `SettingsStruct` in `src/struct-system.go`.
- Removed the `api` default setting from `loadSettings()` in `src/system.go`.