### PR TITLE
Fix: Handle 'Locked' state in pre-refresh hook and add tests

### DIFF
--- a/cmd/xteve-inactive/main.go
+++ b/cmd/xteve-inactive/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -16,53 +17,72 @@ import (
 var port = flag.String("port", "", ": Server port          [34400] (default: 34400)")
 var host = flag.String("host", "", ": Server host                  (default: localhost)")
 
-func main() {
-	flag.Parse()
-
+func runLogic(cmdHost, cmdPort string, outWriter io.Writer, errWriter io.Writer) int {
 	portNum := 34400
-	if port != nil && *port != "" {
+	if cmdPort != "" {
 		var err error
-		portNum, err = strconv.Atoi(*port)
+		portNum, err = strconv.Atoi(cmdPort)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable parse port: %v\n", err)
-			os.Exit(-1)
+			fmt.Fprintf(errWriter, "Unable parse port: %v\n", err)
+			return -1
 		}
 	}
 
 	hostname := "localhost"
-	if host != nil && *host != "" {
-		hostname = *host
+	if cmdHost != "" {
+		hostname = cmdHost
 	}
 
 	requestBody, err := json.Marshal(&xteve.APIRequestStruct{
 		Cmd: "status",
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to marshall request: %v\n", err)
-		os.Exit(-1)
+		fmt.Fprintf(errWriter, "Unable to marshall request: %v\n", err)
+		return -1
 	}
 
 	resp, err := http.Post(fmt.Sprintf("http://%s:%d/api/", hostname, portNum), "application/json", bytes.NewBuffer(requestBody))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to get API: %v\n", err)
-		os.Exit(-1)
+		fmt.Fprintf(errWriter, "Unable to get API: %v\n", err)
+		return -1
 	}
 
 	defer resp.Body.Close()
 
 	respStr, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable read response: %v\n", err)
-		os.Exit(-1)
+		fmt.Fprintf(errWriter, "Unable read response: %v\n", err)
+		return -1
 	}
 
 	var apiresp xteve.APIResponseStruct
 	err = json.Unmarshal(respStr, &apiresp)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable parse response: %v\n", err)
-		fmt.Fprintf(os.Stderr, "%s\n", respStr)
-		os.Exit(-1)
+		if string(respStr) == "Locked [423]" {
+			return 1
+		} else {
+			fmt.Fprintf(errWriter, "Unable parse response: %v\n", err)
+			fmt.Fprintf(errWriter, "%s\n", respStr)
+			return -1
+		}
 	}
 
-	os.Exit(int(apiresp.TunerActive))
+	return int(apiresp.TunerActive)
+}
+
+func main() {
+	flag.Parse()
+
+	cmdPort := "34400"
+	if port != nil && *port != "" {
+		cmdPort = *port
+	}
+
+	cmdHost := "localhost"
+	if host != nil && *host != "" {
+		cmdHost = *host
+	}
+
+	exitCode := runLogic(cmdHost, cmdPort, os.Stdout, os.Stderr)
+	os.Exit(exitCode)
 }

--- a/cmd/xteve-inactive/main_test.go
+++ b/cmd/xteve-inactive/main_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"xteve/src"
+)
+
+func TestRunLogic_LockedError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || r.URL.Path != "/api/" {
+			t.Fatalf("Unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var reqBody src.APIRequestStruct
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Fatalf("Failed to decode request body: %v", err)
+		}
+		if reqBody.Cmd != "status" {
+			t.Fatalf("Expected Cmd 'status', got '%s'", reqBody.Cmd)
+		}
+		fmt.Fprint(w, "Locked [423]")
+	}))
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse server URL: %v", err)
+	}
+	host, port := parsedURL.Hostname(), parsedURL.Port()
+
+	var outBuf, errBuf bytes.Buffer
+	exitCode := runLogic(host, port, &outBuf, &errBuf)
+
+	if exitCode != 1 {
+		t.Errorf("Expected exit code 1, got %d", exitCode)
+	}
+	if errBuf.String() != "" {
+		t.Errorf("Expected empty stderr, got: %s", errBuf.String())
+	}
+	if outBuf.String() != "" {
+		t.Errorf("Expected empty stdout, got: %s", outBuf.String())
+	}
+}
+
+func TestRunLogic_InvalidJSONError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "Not JSON {")
+	}))
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse server URL: %v", err)
+	}
+	host, port := parsedURL.Hostname(), parsedURL.Port()
+
+	var outBuf, errBuf bytes.Buffer
+	exitCode := runLogic(host, port, &outBuf, &errBuf)
+
+	if exitCode != -1 {
+		t.Errorf("Expected exit code -1, got %d", exitCode)
+	}
+	expectedErr := "Unable parse response:"
+	if !strings.Contains(errBuf.String(), expectedErr) {
+		t.Errorf("Expected stderr to contain '%s', got: %s", expectedErr, errBuf.String())
+	}
+	expectedErrBody := "Not JSON {"
+	if !strings.Contains(errBuf.String(), expectedErrBody) {
+		t.Errorf("Expected stderr to contain '%s', got: %s", expectedErrBody, errBuf.String())
+	}
+	if outBuf.String() != "" {
+		t.Errorf("Expected empty stdout, got: %s", outBuf.String())
+	}
+}
+
+func TestRunLogic_TunerInactive(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := src.APIResponseStruct{TunerActive: 0}
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse server URL: %v", err)
+	}
+	host, port := parsedURL.Hostname(), parsedURL.Port()
+
+	var outBuf, errBuf bytes.Buffer
+	exitCode := runLogic(host, port, &outBuf, &errBuf)
+
+	if exitCode != 0 {
+		t.Errorf("Expected exit code 0, got %d", exitCode)
+	}
+	if errBuf.String() != "" {
+		t.Errorf("Expected empty stderr, got: %s", errBuf.String())
+	}
+	if outBuf.String() != "" {
+		t.Errorf("Expected empty stdout, got: %s", outBuf.String())
+	}
+}
+
+func TestRunLogic_TunerActive(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := src.APIResponseStruct{TunerActive: 1}
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse server URL: %v", err)
+	}
+	host, port := parsedURL.Hostname(), parsedURL.Port()
+
+	var outBuf, errBuf bytes.Buffer
+	exitCode := runLogic(host, port, &outBuf, &errBuf)
+
+	if exitCode != 1 {
+		t.Errorf("Expected exit code 1, got %d", exitCode)
+	}
+	if errBuf.String() != "" {
+		t.Errorf("Expected empty stderr, got: %s", errBuf.String())
+	}
+	if outBuf.String() != "" {
+		t.Errorf("Expected empty stdout, got: %s", outBuf.String())
+	}
+}
+
+func TestRunLogic_ServerDown(t *testing.T) {
+	var outBuf, errBuf bytes.Buffer
+	// Attempt to connect to a port that is presumably not listening
+	exitCode := runLogic("localhost", "1", &outBuf, &errBuf)
+
+	if exitCode != -1 {
+		t.Errorf("Expected exit code -1, got %d", exitCode)
+	}
+	expectedErr := "Unable to get API:"
+	if !strings.Contains(errBuf.String(), expectedErr) {
+		t.Errorf("Expected stderr to contain '%s', got: %s", expectedErr, errBuf.String())
+	}
+	if outBuf.String() != "" {
+		t.Errorf("Expected empty stdout, got: %s", outBuf.String())
+	}
+}


### PR DESCRIPTION
The snap pre-refresh hook was failing when the xTeVe API returned a "Locked [423]" message. This occurred because the `xteve-inactive` utility, called by the hook, would print this non-JSON message to stderr and exit, causing the snap refresh mechanism to error out due to an unparseable response.

This commit addresses the issue by modifying `cmd/xteve-inactive/main.go`:
- If the API response is "Locked [423]", `xteve-inactive` now exits with status code 1 (signifying busy/active) and does not print the "Locked" message to stderr or stdout. This prevents the snap refresh from failing and correctly indicates that xTeVe is not in a state to be refreshed.
- Other JSON parsing errors or HTTP errors continue to be printed to stderr, and the program exits with -1.

Additionally, this commit introduces:
- Refactoring of `cmd/xteve-inactive/main.go` to improve testability by separating the core logic into a `runLogic` function.
- A new test suite (`cmd/xteve-inactive/main_test.go`) with comprehensive tests for `xteve-inactive`. These tests cover scenarios including:
    - API returning "Locked [423]"
    - API returning other invalid JSON
    - API returning valid responses (tuner active/inactive)
    - API server being down

The existing CI configuration already includes `go test ./...`, so the new tests will be run automatically. The `snap/hooks/pre-refresh` script did not require changes as it correctly interprets a non-zero exit code from `xteve-inactive` as a signal to abort the refresh.