### PR TITLE
Refactor: Remove LXD from snap CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,16 +70,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-kvm
           sudo snap install snapcraft --classic
-          sudo snap install lxd
-      - name: Initialize LXD
-        run: sudo lxd init --auto
-      - name: Add user to lxd group
-        run: |
-          sudo groupadd --system lxd || true
-          sudo usermod -a -G lxd $USER || true
-          # The new session part is tricky in CI. sg lxd -c "command" will be used later for snapcraft.
-          # Re-login or newgrp is not feasible in most CI script flows.
-          # We rely on `sg lxd -c "snapcraft"` for the build step to use the new group membership.
       - name: Build the snap
         run: sudo snapcraft --destructive-mode
       - name: Install the snap


### PR DESCRIPTION
LXD is no longer required for building the snap in your CI pipeline. The `snapcraft` command uses `--destructive-mode`, which allows it to build directly on the host system. This change removes the LXD installation and initialization steps from the `snap-test` job, simplifying the CI process.