### PR TITLE
fix(snap): Handle newlines in pre-refresh hook

### DIFF
--- a/cmd/xteve-inactive/main.go
+++ b/cmd/xteve-inactive/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 
 	xteve "xteve/src"
 )
@@ -57,7 +58,7 @@ func runLogic(cmdHost, cmdPort string, outWriter io.Writer, errWriter io.Writer)
 	var apiresp xteve.APIResponseStruct
 	err = json.Unmarshal(respStr, &apiresp)
 	if err != nil {
-		if string(respStr) == "Locked [423]" {
+		if strings.TrimSpace(string(respStr)) == "Locked [423]" {
 			return 1
 		} else {
 			fmt.Fprintf(errWriter, "Unable parse response: %v\n", err)


### PR DESCRIPTION
The pre-refresh hook executes the `xteve-inactive` command to check if the service is busy. This command makes an API call that can return the string "Locked [423]".

The code was checking for this exact string, but the server was returning "Locked [423]\n" with a newline. This caused the check to fail and the pre-refresh hook to error out, preventing snap updates.

This change uses `strings.TrimSpace` to remove any leading or trailing whitespace from the response before the comparison, making the check more robust and fixing the snap refresh process.