### PR TITLE
refactor: Replace deprecated io/ioutil with io and os packages

### DIFF
--- a/cmd/ci-test/main.go
+++ b/cmd/ci-test/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -189,7 +189,7 @@ func runTests() error {
 	}
 	defer httpResp.Body.Close()
 
-	body, err := ioutil.ReadAll(httpResp.Body)
+	body, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read M3U file body: %w", err)
 	}

--- a/src/internal/authentication/authentication.go
+++ b/src/internal/authentication/authentication.go
@@ -3,7 +3,6 @@ package authentication
 import (
 	"encoding/json"
 	"errors"
-	// "io/ioutil" // Will be removed
 	"net/http"
 	"os"
 	"path/filepath"

--- a/src/internal/imgcache/cache.go
+++ b/src/internal/imgcache/cache.go
@@ -3,7 +3,6 @@ package imgcache
 import (
 	"fmt"
 	"io"
-	// "io/ioutil" // Will be removed
 	"net/http"
 	"net/url"
 	"os"


### PR DESCRIPTION
This commit replaces the deprecated `io/ioutil` package with functions from the `io` and `os` packages. The `ioutil.ReadAll` function has been replaced with `io.ReadAll`, and commented-out imports of `io/ioutil` have been removed from the codebase.