### PR TITLE
Fix e2e channel test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ html/js/
 /.idea/*
 .xteve/
 __debug_bin
+xteve_test_binary*

--- a/cmd/ci-test/main.go
+++ b/cmd/ci-test/main.go
@@ -142,7 +142,7 @@ func runTests() error {
 	m3uData := map[string]interface{}{
 		"-": map[string]interface{}{ // Use "-" to indicate a new file
 			"name": "CSPAN",
-			"url":  "https://raw.githubusercontent.com/freearhey/iptv-usa/main/c-span.us.m3u",
+			"url":  "src/testdata/c-span.us.m3u",
 		},
 	}
 	// Correct key is "files" with a nested "m3u" map

--- a/src/testdata/c-span.us.m3u
+++ b/src/testdata/c-span.us.m3u
@@ -1,0 +1,7 @@
+#EXTM3U
+#EXTINF:-1 tvg-id="CSPAN.us" tvg-name="C-SPAN" tvg-logo="https://i.imgur.com/SAyXl2E.png" group-title="News",C-SPAN
+http://example.com/cspan
+#EXTINF:-1 tvg-id="CSPAN2.us" tvg-name="C-SPAN 2" tvg-logo="https://i.imgur.com/E4I0OA9.png" group-title="News",C-SPAN 2
+http://example.com/cspan2
+#EXTINF:-1 tvg-id="CSPAN3.us" tvg-name="C-SPAN 3" tvg-logo="https://i.imgur.com/df90v1t.png" group-title="News",C-SPAN 3
+http://example.com/cspan3

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -595,7 +595,7 @@ func WS(w http.ResponseWriter, r *http.Request) {
 		response.Settings = Settings
 	}
 
-	// response = setDefaultResponseData(response, true)
+	response = setDefaultResponseData(response, true)
 	if System.ConfigurationWizard {
 		response.ConfigurationWizard = System.ConfigurationWizard
 	}

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -595,7 +595,7 @@ func WS(w http.ResponseWriter, r *http.Request) {
 		response.Settings = Settings
 	}
 
-	response = setDefaultResponseData(response, true)
+	// response = setDefaultResponseData(response, true)
 	if System.ConfigurationWizard {
 		response.ConfigurationWizard = System.ConfigurationWizard
 	}


### PR DESCRIPTION
I've been working on the failing e2e channel test. The original problem was that the test relied on a remote M3U file that was no longer available, so I replaced it with a local one.

However, this change revealed a deeper issue that causes the server to crash when a new M3U playlist is added. I've committed the failing test case, which you can run with `go run cmd/ci-test/main.go`. The test now reliably reproduces the crash, allowing me to debug the root cause.