### PR TITLE
feat: Optimize regular expression compilation

### DIFF
--- a/src/struct-system.go
+++ b/src/struct-system.go
@@ -2,6 +2,7 @@ package src
 
 import (
 	"net"
+	"regexp"
 	"xteve/src/internal/imgcache"
 )
 
@@ -202,6 +203,8 @@ type XEPGChannelStruct struct {
 	XUpdateChannelGroup           bool   `json:"x-update-channel-group"`
 	XDescription                  string `json:"x-description"`
 	XTimeshift                    string `json:"x-timeshift"`
+	CompiledNameRegex             *regexp.Regexp `json:"-"`
+	CompiledGroupRegex            *regexp.Regexp `json:"-"`
 }
 
 // M3UChannelStructXEPG : M3U Structure for XEPG

--- a/src/xepg.go
+++ b/src/xepg.go
@@ -256,6 +256,20 @@ func createXEPGDatabase() (err error) {
 		if err != nil {
 			return
 		}
+
+		if len(channel.UpdateChannelNameRegex) > 0 {
+			channel.CompiledNameRegex, err = regexp.Compile(channel.UpdateChannelNameRegex)
+			if err != nil {
+				ShowError(err, 1018)
+			}
+		}
+
+		if len(channel.UpdateChannelNameByGroupRegex) > 0 {
+			channel.CompiledGroupRegex, err = regexp.Compile(channel.UpdateChannelNameByGroupRegex)
+			if err != nil {
+				ShowError(err, 1018)
+			}
+		}
 		channelHash := generateChannelHash(channel.FileM3UID, channel.Name, channel.GroupTitle, channel.TvgID, channel.TvgName, channel.UUIDKey, channel.UUIDValue)
 		xepgChannelsValuesMap[channelHash] = channel
 	}
@@ -313,21 +327,17 @@ func createXEPGDatabase() (err error) {
 					if dxc.Name == m3uChannel.Name {
 						continue
 					}
-					nameRx, err := regexp.Compile(dxc.UpdateChannelNameRegex)
-					if err != nil {
-						ShowError(err, 1018)
+
+					if dxc.CompiledNameRegex == nil {
 						continue
 					}
-					if !nameRx.MatchString(m3uChannel.Name) {
+
+					if !dxc.CompiledNameRegex.MatchString(m3uChannel.Name) {
 						continue
 					}
-					if len(dxc.UpdateChannelNameByGroupRegex) > 0 {
-						groupRx, err := regexp.Compile(dxc.UpdateChannelNameByGroupRegex)
-						if err != nil {
-							ShowError(err, 1018)
-							continue
-						}
-						if !groupRx.MatchString(dxc.XGroupTitle) {
+
+					if dxc.CompiledGroupRegex != nil {
+						if !dxc.CompiledGroupRegex.MatchString(dxc.XGroupTitle) {
 							// Found the channel name to update but it has wrong group
 							continue
 						}


### PR DESCRIPTION
This commit addresses a performance issue where regular expressions for channel name and group updates were being compiled on every execution within a loop in the `createXEPGDatabase` function.

To fix this, the regular expressions are now pre-compiled and stored within the `XEPGChannelStruct`.

Changes include:
- Added `CompiledNameRegex` and `CompiledGroupRegex` fields of type `*regexp.Regexp` to `XEPGChannelStruct`.
- The regexes are now compiled once after the channel data is loaded and stored in these new fields.
- The channel update logic now uses the pre-compiled regexes, avoiding repeated compilation and improving performance.