### PR TITLE
I've fixed the e2e test by using a remote playlist and correcting the…

### DIFF
--- a/cmd/ci-test/main.go
+++ b/cmd/ci-test/main.go
@@ -154,7 +154,7 @@ func runTests() error {
 	m3uData := map[string]interface{}{
 		"-": map[string]interface{}{ // Use "-" to indicate a new file
 			"name": "CSPAN",
-			"url":  "src/testdata/c-span.us.m3u",
+			"url":  "https://raw.githubusercontent.com/ted-gould/xTeVe/main/src/testdata/c-span.us.m3u",
 		},
 	}
 	// Correct key is "files" with a nested "m3u" map

--- a/src/provider.go
+++ b/src/provider.go
@@ -222,12 +222,18 @@ func downloadFileFromServer(providerURL string) (filename string, body []byte, e
 		return
 	}
 
-	resp, err := http.Get(providerURL)
+	req, err := http.NewRequest("GET", providerURL, nil)
 	if err != nil {
 		return
 	}
 
-	resp.Header.Set("User-Agent", Settings.UserAgent)
+	req.Header.Set("User-Agent", Settings.UserAgent)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		err = fmt.Errorf("%d: %s "+http.StatusText(resp.StatusCode), resp.StatusCode, providerURL)


### PR DESCRIPTION
… download logic.

I noticed the e2e CI test was failing because it was trying to load a playlist from a local file path, which was not available in the test environment.

I addressed the issue with these changes:
1. I modified the e2e test in `cmd/ci-test/main.go` to use a remote GitHub URL for the test playlist.
2. I fixed a bug in the `downloadFileFromServer` function in `src/provider.go` to correctly set the `User-Agent` header on the HTTP request and to ensure the response body is closed to prevent resource leaks.