### PR TITLE
fix(build): Resolve TypeScript compilation error

### DIFF
--- a/ts/compileJS.sh
+++ b/ts/compileJS.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-tsc -p tsconfig.json
+npx tsc -p tsconfig.json

--- a/ts/settings_ts.ts
+++ b/ts/settings_ts.ts
@@ -775,45 +775,6 @@ class SettingsCategory {
   }
 }
 
-// Settings
-var settingsCategory = new Array();
-settingsCategory.push(
-  new SettingsCategoryItem(
-    "{{.settings.general.title}}",
-    "hostIP,hostName,port,tuner,epgSource,api,ssdp,tlsMode",
-  ),
-);
-settingsCategory.push(
-  new SettingsCategoryItem(
-    "{{.settings.files.title}}",
-    "files.update,update,cache.images,xepg.replace.missing.images,clearXMLTVCache",
-  ),
-);
-settingsCategory.push(
-  new SettingsCategoryItem(
-    "{{.settings.streaming.title}}",
-    "buffer,buffer.size.kb,storeBufferInRAM,buffer.timeout,stream.retry.enabled,stream.max.retries,stream.retry.delay,user.agent,udpxy",
-  ),
-);
-settingsCategory.push(
-  new SettingsCategoryItem(
-    "{{.settings.backup.title}}",
-    "backup.path,backup.keep",
-  ),
-);
-settingsCategory.push(
-  new SettingsCategoryItem(
-    "{{.settings.authentication.title}}",
-    "authentication.web,authentication.pms,authentication.m3u,authentication.xml,authentication.api",
-  ),
-);
-settingsCategory.push(
-  new SettingsCategoryItem(
-    "{{.settings.misc.title}}",
-    "defaultMissingEPG,enableMappedChannels,disallowURLDuplicates",
-  ),
-);
-
 class SettingsCategoryItem extends SettingsCategory {
   headline: string;
   settingsKeys: string;
@@ -861,6 +822,45 @@ class SettingsCategoryItem extends SettingsCategory {
     doc.appendChild(this.createHR());
   }
 }
+
+// Settings
+var settingsCategory = new Array();
+settingsCategory.push(
+  new SettingsCategoryItem(
+    "{{.settings.general.title}}",
+    "hostIP,hostName,port,tuner,epgSource,api,ssdp,tlsMode",
+  ),
+);
+settingsCategory.push(
+  new SettingsCategoryItem(
+    "{{.settings.files.title}}",
+    "files.update,update,cache.images,xepg.replace.missing.images,clearXMLTVCache",
+  ),
+);
+settingsCategory.push(
+  new SettingsCategoryItem(
+    "{{.settings.streaming.title}}",
+    "buffer,buffer.size.kb,storeBufferInRAM,buffer.timeout,stream.retry.enabled,stream.max.retries,stream.retry.delay,user.agent,udpxy",
+  ),
+);
+settingsCategory.push(
+  new SettingsCategoryItem(
+    "{{.settings.backup.title}}",
+    "backup.path,backup.keep",
+  ),
+);
+settingsCategory.push(
+  new SettingsCategoryItem(
+    "{{.settings.authentication.title}}",
+    "authentication.web,authentication.pms,authentication.m3u,authentication.xml,authentication.api",
+  ),
+);
+settingsCategory.push(
+  new SettingsCategoryItem(
+    "{{.settings.misc.title}}",
+    "defaultMissingEPG,enableMappedChannels,disallowURLDuplicates",
+  ),
+);
 
 function showSettings() {
   for (let i = 0; i < settingsCategory.length; i++) {


### PR DESCRIPTION
The build was failing with the error 'TS2449: Class used before its declaration' in settings_ts.ts. This was because the SettingsCategoryItem class was being instantiated before its declaration.

I've fixed the issue by reordering the code in settings_ts.ts to ensure that the SettingsCategoryItem class is declared before it is used.

Additionally, I've updated the build script ts/compileJS.sh to use 'npx tsc' instead of 'tsc'. This ensures that the locally installed TypeScript compiler from node_modules is used, which improves build consistency across different environments.