### PR TITLE
fix: Set correct MIME type for JavaScript files

### DIFF
--- a/src/webserver.go
+++ b/src/webserver.go
@@ -3,6 +3,7 @@ package src
 import (
 	"context"
 	"encoding/json"
+	"mime"
 	"errors"
 	"fmt"
 	"io"
@@ -24,6 +25,11 @@ import (
 // webAlerts channel to send to client
 var webAlerts = make(chan string, 3)
 var restartWebserver = make(chan bool, 1)
+
+func init() {
+	// Fix for MIME type issue with .js files
+	_ = mime.AddExtensionType(".js", "application/javascript")
+}
 
 // StartWebserver : Start the Webserver
 func StartWebserver() (err error) {

--- a/src/webserver_test.go
+++ b/src/webserver_test.go
@@ -1,0 +1,15 @@
+package src
+
+import (
+	"mime"
+	"testing"
+)
+
+func TestMimeTypeJS(t *testing.T) {
+	expectedMimeType := "application/javascript"
+	actualMimeType := mime.TypeByExtension(".js")
+
+	if actualMimeType != expectedMimeType {
+		t.Errorf("Expected MIME type for .js to be %s, but got %s", expectedMimeType, actualMimeType)
+	}
+}


### PR DESCRIPTION
The web server was serving JavaScript files with the `Content-Type` header set to `text/plain`. This caused modern browsers to block the files due to the `X-Content-Type-Options: nosniff` header.

This change fixes the issue by explicitly registering the `application/javascript` MIME type for the `.js` extension at application startup.

A Go test has been added to verify that the MIME type for `.js` files is correctly registered.