### PR TITLE
Fix(filter): Correctly apply group-title filter conditions

### DIFF
--- a/src/m3u.go
+++ b/src/m3u.go
@@ -49,7 +49,6 @@ func FilterThisStream(s any) (status bool) {
 	}
 
 	// Cache raw stream values. Normalize _values once.
-	rawStreamName, streamNameOK := stream["name"]
 	rawStreamGroup, streamGroupOK := stream["group-title"]
 	rawStreamValues, streamValuesOK := stream["_values"]
 	if streamValuesOK {
@@ -67,7 +66,6 @@ func FilterThisStream(s any) (status bool) {
 		var searchTarget string // This will hold the stream value to search within (e.g., name or _values)
 
 		// Determine effective stream and rule values based on case sensitivity
-		var effectiveStreamName = rawStreamName
 		var effectiveStreamGroup = rawStreamGroup
 		var effectiveStreamValues = rawStreamValues
 		var effectiveMainFilterRulePart string // Declare, assign after baseFilterRule is processed
@@ -95,9 +93,6 @@ func FilterThisStream(s any) (status bool) {
 			exclude = strings.ToLower(exclude) // Lowercase exclude if filter is case-insensitive
 			include = strings.ToLower(include) // Lowercase include if filter is case-insensitive
 
-			if streamNameOK {
-				effectiveStreamName = strings.ToLower(rawStreamName)
-			}
 			if streamGroupOK {
 				effectiveStreamGroup = strings.ToLower(rawStreamGroup)
 			}
@@ -109,7 +104,7 @@ func FilterThisStream(s any) (status bool) {
 		// Perform the match based on filter type
 		switch filter.Type {
 		case "group-title":
-			searchTarget = effectiveStreamName // For group-title, conditions check against stream name
+			searchTarget = effectiveStreamGroup // For group-title, conditions check against stream group
 			if streamGroupOK && effectiveStreamGroup == effectiveMainFilterRulePart {
 				match = true
 				stream["_preserve-mapping"] = strconv.FormatBool(filter.PreserveMapping)

--- a/src/m3u_test.go
+++ b/src/m3u_test.go
@@ -1,0 +1,112 @@
+package src
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterThisStream_GroupTitle_Bug(t *testing.T) {
+	// This test demonstrates the bug.
+	// A stream with group-title="News" and name="National Report"
+	// should be matched by a filter on group-title="News" with an include condition of "{News}".
+	// The bug causes this to fail because the include condition is checked against the stream name instead of the group title.
+
+	// Setup: Create a stream
+	stream := map[string]string{
+		"name":        "National Report",
+		"group-title": "News",
+		"_values":     "National Report;News",
+	}
+
+	// Setup: Create a filter
+	filter := Filter{
+		Type:          "group-title",
+		Rule:          "News {News}",
+		CaseSensitive: false,
+	}
+
+	// Setup: Reset and populate Data.Filter
+	Data.Filter = []Filter{filter}
+
+	// Execute
+	result := FilterThisStream(stream)
+
+	// Assert: This will fail before the fix
+	assert.True(t, result, "Stream should be matched by the filter")
+}
+
+func TestFilterThisStream_CustomFilter(t *testing.T) {
+	// This test ensures that the custom-filter functionality is not broken.
+
+	// Setup: Create a stream
+	stream := map[string]string{
+		"name":        "Some Channel",
+		"group-title": "Some Group",
+		"_values":     "Some Channel;Some Group;keyword",
+	}
+
+	// Setup: Create a filter
+	filter := Filter{
+		Type:          "custom-filter",
+		Rule:          "keyword",
+		CaseSensitive: false,
+	}
+	Data.Filter = []Filter{filter}
+
+	// Execute
+	result := FilterThisStream(stream)
+
+	// Assert
+	assert.True(t, result, "Stream should be matched by the custom filter")
+}
+
+func TestFilterThisStream_GroupTitle_SpecialCharacters(t *testing.T) {
+	// This test ensures that group-title filters with special characters are handled correctly.
+
+	// Setup: Create a stream
+	stream := map[string]string{
+		"name":        "Some Channel",
+		"group-title": "!@#$%^&*()_+-=[]{};':\",./<>?",
+		"_values":     "Some Channel;!@#$%^&*()_+-=[]{};':\",./<>?",
+	}
+
+	// Setup: Create a filter
+	filter := Filter{
+		Type:          "group-title",
+		Rule:          "!@#$%^&*()_+-=[]{};':\",./<>?",
+		CaseSensitive: true,
+	}
+	Data.Filter = []Filter{filter}
+
+	// Execute
+	result := FilterThisStream(stream)
+
+	// Assert
+	assert.True(t, result, "Stream should be matched by the filter with special characters")
+}
+
+func TestFilterThisStream_GroupTitle_UnicodeCharacters(t *testing.T) {
+	// This test ensures that group-title filters with unicode characters are handled correctly.
+
+	// Setup: Create a stream
+	stream := map[string]string{
+		"name":        "Some Channel",
+		"group-title": "뉴스", // "News" in Korean
+		"_values":     "Some Channel;뉴스",
+	}
+
+	// Setup: Create a filter
+	filter := Filter{
+		Type:          "group-title",
+		Rule:          "뉴스",
+		CaseSensitive: false,
+	}
+	Data.Filter = []Filter{filter}
+
+	// Execute
+	result := FilterThisStream(stream)
+
+	// Assert
+	assert.True(t, result, "Stream should be matched by the filter with unicode characters")
+}


### PR DESCRIPTION
The filtering logic for `group-title` filters was incorrectly applying include/exclude conditions against the stream's name instead of its group title. This caused filters with these conditions to fail unexpectedly.

This commit corrects the logic to ensure that for `group-title` filters, the `searchTarget` for include/exclude conditions is the stream's group title.

Additionally, a comprehensive test suite for the `FilterThisStream` function has been added in `src/m3u_test.go`. This includes tests that:
- Specifically reproduce and verify the fix for the bug.
- Check for regressions in `custom-filter` functionality.
- Verify correct handling of special characters and Unicode characters in group titles.