### PR TITLE
feat: Add Playwright test for login screen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,30 @@ jobs:
       - name: Run E2E test
         run: go run cmd/ci-test/main.go
 
+  playwright-test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.1'
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm install
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Run app
+        run: |
+          go build -o xteve_test_binary xteve.go
+          ./xteve_test_binary -port=34400 &
+      - name: Run Playwright tests
+        run: npx playwright test --project=chromium
+
   format:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
           go build -o xteve_test_binary xteve.go
           ./xteve_test_binary -port=34400 &
       - name: Run Playwright tests
-        run: npx playwright test --project=chromium
+        run: npx playwright test
 
   format:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ xteve_test_binary*
 src/html/js/
 bin/
 node_modules/
+test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,72 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "@playwright/test": "^1.46.0",
         "prettier": "^3.6.2",
         "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/prettier": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "test:playwright": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -22,6 +23,7 @@
   },
   "homepage": "https://github.com/ted-gould/xTeVe#readme",
   "devDependencies": {
+    "@playwright/test": "^1.46.0",
     "prettier": "^3.6.2",
     "typescript": "^5.9.2"
   }

--- a/playwright_tests/login.spec.ts
+++ b/playwright_tests/login.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+  await page.goto('http://localhost:34400/web/');
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/xTeVe/);
+});

--- a/playwright_tests/login.spec.ts
+++ b/playwright_tests/login.spec.ts
@@ -1,7 +1,7 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test('has title', async ({ page }) => {
-  await page.goto('http://localhost:34400/web/');
+test("has title", async ({ page }) => {
+  await page.goto("http://localhost:34400/web/");
 
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle(/xTeVe/);


### PR DESCRIPTION
This change introduces a new Playwright test to ensure the initial login screen is accessible.

A new Playwright test, `playwright_tests/login.spec.ts`, has been created to navigate to the web UI and verify that the page title is "xTeVe". This serves as a basic check to confirm that the login screen is loading correctly.

A new CI job, `playwright-test`, has been added to `.github/workflows/ci.yml`. This job builds the application, runs it in the background, and then executes the Playwright tests.

The `@playwright/test` dependency has been added to `package.json`.

The `test-results/` directory, which is generated by Playwright, has been added to `.gitignore`.