### PR TITLE
Fix(filter): Correct exclude logic for group-title filters

### DIFF
--- a/src/m3u.go
+++ b/src/m3u.go
@@ -109,6 +109,7 @@ func FilterThisStream(s any) (status bool) {
 				match = true
 				stream["_preserve-mapping"] = strconv.FormatBool(filter.PreserveMapping)
 				stream["_starting-channel"] = filter.StartingChannel
+				searchTarget = effectiveStreamValues
 			}
 		case "custom-filter":
 			searchTarget = effectiveStreamValues // For custom-filter, conditions check against stream values


### PR DESCRIPTION
The `FilterThisStream` function was incorrectly using the `group-title` as the search target for `exclude` and `include` conditions within a `group-title` filter. This meant the conditions were not being evaluated against the channel's name or other metadata.

This change updates the `searchTarget` to use the full `effectiveStreamValues` after the initial group match, ensuring conditions are evaluated correctly.

Fix(xepg): Allow auto-mapping for active channels

The `performAutomaticChannelMapping` function had a condition that prevented it from running on channels that were already marked as active. This prevented new channels from receiving a default EPG mapping, causing them to be deactivated.

The incorrect `if !xepgChannel.XActive` condition has been removed.