### PR TITLE
fix(web): serve js files with correct mime type

### DIFF
--- a/src/webserver.go
+++ b/src/webserver.go
@@ -626,6 +626,22 @@ func init() {
 func Web(w http.ResponseWriter, r *http.Request) {
 	var path = r.URL.Path
 
+	// Custom handler for .js files to ensure correct MIME type
+	if strings.HasSuffix(path, ".js") {
+		fsPath := "html" + strings.TrimPrefix(path, "/web")
+		content, err := webUI.ReadFile(fsPath)
+		if err != nil {
+			httpStatusError(w, r, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/javascript")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(content); err != nil {
+			log.Printf("Error writing response in Web handler for %s: %v", path, err)
+		}
+		return
+	}
+
 	// Serve static assets using the file server
 	if !strings.HasSuffix(path, ".html") && path != "/web/" && path != "/web" {
 		webHandler.ServeHTTP(w, r)

--- a/src/webserver_test.go
+++ b/src/webserver_test.go
@@ -2,7 +2,11 @@ package src
 
 import (
 	"mime"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMimeTypeJS(t *testing.T) {
@@ -11,5 +15,41 @@ func TestMimeTypeJS(t *testing.T) {
 
 	if actualMimeType != expectedMimeType {
 		t.Errorf("Expected MIME type for .js to be %s, but got %s", expectedMimeType, actualMimeType)
+	}
+}
+
+func TestJSFileMimeTypeE2E(t *testing.T) {
+	// GIVEN
+	// A new test server
+	server := httptest.NewServer(http.HandlerFunc(Web))
+	defer server.Close()
+
+	// A list of JS files to test
+	jsFiles := []string{
+		"/web/js/network_ts.js",
+		"/web/js/authentication_ts.js",
+		"/web/js/base_ts.js",
+		"/web/js/configuration_ts.js",
+		"/web/js/logs_ts.js",
+		"/web/js/menu_ts.js",
+		"/web/js/settings_ts.js",
+	}
+
+	for _, jsFile := range jsFiles {
+		// WHEN
+		// We make a request to the test server for a JS file
+		url := server.URL + jsFile
+		resp, err := http.Get(url)
+		assert.NoError(t, err, "Failed to get URL '%s'", url)
+		defer resp.Body.Close()
+
+		// THEN
+		// The response should be successful
+		assert.Equal(t, http.StatusOK, resp.StatusCode, "for file '%s'", jsFile)
+
+		// The Content-Type should be exactly "application/javascript"
+		expectedContentType := "application/javascript"
+		actualContentType := resp.Header.Get("Content-Type")
+		assert.Equal(t, expectedContentType, actualContentType, "for file '%s', unexpected content type", jsFile)
 	}
 }


### PR DESCRIPTION
The web server was serving JavaScript files with the MIME type 'text/plain', which caused them to be blocked by browsers.

This commit modifies the `Web` handler to specifically handle `.js` files, setting their `Content-Type` to `application/javascript`.

An E2E test is also added to `src/webserver_test.go` to verify the fix and prevent regressions.