### PR TITLE
feat: Add startup check for JS files and fix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,13 +128,16 @@ jobs:
         with:
           node-version: '20'
       - name: Install dependencies
-        run: npm install
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make ffmpeg
+          npm install
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run app
         run: |
-          go build -o xteve_test_binary xteve.go
-          ./xteve_test_binary -port=34400 &
+          make build
+          ./bin/xteve -port=34400 &
       - name: Run Playwright tests
         run: npx playwright test
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build: ts-compile generate-video
 
 ts-compile:
 	@echo "--- Compiling TypeScript ---"
-	(cd ts && npx tsc -p tsconfig.json)
+	(npm install && cd ts && npx tsc)
 
 generate-video:
 	@echo "--- Generating video asset ---"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,7 +19,10 @@ parts:
       - ffmpeg
     build-snaps:
       - go
+      - node/20/stable
     override-build: |
+      npm install
+      (cd ts && npx tsc)
       ./build/generate_video.sh
       snapcraftctl build
     override-stage: |

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -618,6 +618,20 @@ func init() {
 	if err != nil {
 		log.Fatal("Failed to create sub-filesystem for embedded resources: ", err)
 	}
+
+	// Check if JS files exist.
+	jsFiles, err := fs.ReadDir(htmlFS, "js")
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			log.Fatal("Embedded 'html/js' directory not found. Please run 'make build' to compile the TypeScript files.")
+		}
+		log.Fatal("Failed to read embedded 'html/js' directory: ", err)
+	}
+
+	if len(jsFiles) == 0 {
+		log.Fatal("No JavaScript files found in embedded 'html/js' directory. Please run 'make build' to compile the TypeScript files.")
+	}
+
 	fileServer := http.FileServer(http.FS(htmlFS))
 	webHandler = http.StripPrefix("/web/", fileServer)
 }


### PR DESCRIPTION
The webserver was returning a 404 for JavaScript files because the TypeScript compilation step was not being run, or was failing silently.

To fix this, I made two improvements:

1.  I updated the `ts-compile` target in the `Makefile` to run `npm install` before compiling. This ensures that all necessary dependencies are present, making the build process more robust.

2.  I added a startup check to the Go webserver. It verifies that the embedded filesystem contains the compiled JavaScript files. If the files are missing, the server will panic with a clear error message that instructs you to run `make build`. This prevents the server from running in a broken state and provides a much better developer experience than a runtime 404 error.