### PR TITLE
fix(http): Follow HTTP redirects instead of treating them as errors

### DIFF
--- a/src/buffer.go
+++ b/src/buffer.go
@@ -609,33 +609,10 @@ func connectToStreamingServer(streamID int, playlistID string) {
 			debugRequest(req)
 
 			client := &http.Client{}
-			client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-				return errors.New("Redirect")
-			}
 
 			resp, err := connectWithRetry(client, req)
 
 			if err != nil {
-				// Redirect
-				if resp != nil && resp.StatusCode >= 301 && resp.StatusCode <= 308 {
-					debug = fmt.Sprintf("Streaming Status:HTTP response status [%d] %s", resp.StatusCode, http.StatusText(resp.StatusCode))
-					showDebug(debug, 2)
-					currentURL = strings.Trim(resp.Header.Get("Location"), "\r\n")
-					stream.Location = currentURL
-					if len(currentURL) > 0 {
-						debug = fmt.Sprintf("HTTP Redirect:%s", stream.Location)
-						showDebug(debug, 2)
-						defer resp.Body.Close()
-						goto Redirect
-					} else {
-						err = errors.New("streaming server")
-						ShowError(err, 4002)
-						addErrorToStream(err)
-						defer resp.Body.Close()
-						return
-					}
-				}
-
 				ShowError(err, 0)
 				addErrorToStream(err)
 				if resp != nil {
@@ -703,9 +680,6 @@ func connectToStreamingServer(streamID int, playlistID string) {
 
 				if stream.HLS {
 					client := &http.Client{}
-					client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-						return errors.New("Redirect")
-					}
 
 					for _, segment := range stream.Segment {
 						req, _ := http.NewRequest("GET", segment.URL, nil)

--- a/src/buffer_test.go
+++ b/src/buffer_test.go
@@ -15,7 +15,9 @@ func TestConnectWithRetry(t *testing.T) {
 				http.Redirect(w, r, "/target", http.StatusFound)
 			} else if r.URL.Path == "/target" {
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte("Hello, world!"))
+				if _, err := w.Write([]byte("Hello, world!")); err != nil {
+					t.Fatalf("w.Write failed: %v", err)
+				}
 			} else {
 				http.NotFound(w, r)
 			}

--- a/src/buffer_test.go
+++ b/src/buffer_test.go
@@ -1,12 +1,53 @@
 package src
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
 
 func TestConnectWithRetry(t *testing.T) {
+	t.Run("Follows Redirects", func(t *testing.T) {
+		// Create a mock server
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/redirect" {
+				http.Redirect(w, r, "/target", http.StatusFound)
+			} else if r.URL.Path == "/target" {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("Hello, world!"))
+			} else {
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+
+		// Setup settings for retry
+		Settings.StreamRetryEnabled = false // No retries for this test
+
+		req, _ := http.NewRequest("GET", server.URL+"/redirect", nil)
+		client := &http.Client{}
+
+		resp, err := connectWithRetry(client, req)
+		if err != nil {
+			t.Fatalf("connectWithRetry failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Expected status code %d, but got %d", http.StatusOK, resp.StatusCode)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("Failed to read response body: %v", err)
+		}
+
+		if string(body) != "Hello, world!" {
+			t.Errorf("Expected response body 'Hello, world!', but got '%s'", string(body))
+		}
+	})
+
 	t.Run("Initial Connection", func(t *testing.T) {
 		// Counter for how many times the server has been hit
 		hitCount := 0


### PR DESCRIPTION
The HTTP client was configured to prevent automatic redirects and instead return an error. This caused streams that use redirects to fail.

This change removes the custom redirect handling and allows the `http.Client` to use its default behavior, which is to follow redirects automatically. This fixes the issue where redirects were being logged as stream errors.