### PR TITLE
fix: Correctly parse templates in JavaScript files

### DIFF
--- a/src/webserver.go
+++ b/src/webserver.go
@@ -640,24 +640,8 @@ func init() {
 func Web(w http.ResponseWriter, r *http.Request) {
 	var path = r.URL.Path
 
-	// Custom handler for .js files to ensure correct MIME type
-	if strings.HasSuffix(path, ".js") {
-		fsPath := "html" + strings.TrimPrefix(path, "/web")
-		content, err := webUI.ReadFile(fsPath)
-		if err != nil {
-			httpStatusError(w, r, http.StatusNotFound)
-			return
-		}
-		w.Header().Set("Content-Type", "application/javascript")
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write(content); err != nil {
-			log.Printf("Error writing response in Web handler for %s: %v", path, err)
-		}
-		return
-	}
-
 	// Serve static assets using the file server
-	if !strings.HasSuffix(path, ".html") && path != "/web/" && path != "/web" {
+	if !strings.HasSuffix(path, ".html") && !strings.HasSuffix(path, ".js") && path != "/web/" && path != "/web" {
 		webHandler.ServeHTTP(w, r)
 		return
 	}

--- a/src/webserver_test.go
+++ b/src/webserver_test.go
@@ -1,6 +1,7 @@
 package src
 
 import (
+	"io"
 	"mime"
 	"net/http"
 	"net/http/httptest"
@@ -52,4 +53,29 @@ func TestJSFileMimeTypeE2E(t *testing.T) {
 		actualContentType := resp.Header.Get("Content-Type")
 		assert.Equal(t, expectedContentType, actualContentType, "for file '%s', unexpected content type", jsFile)
 	}
+}
+
+func TestJSTemplate(t *testing.T) {
+	// GIVEN
+	// A new test server
+	server := httptest.NewServer(http.HandlerFunc(Web))
+	defer server.Close()
+
+	// WHEN
+	// We make a request to the test server for a JS file that contains a template
+	url := server.URL + "/web/js/settings_ts.js"
+	resp, err := http.Get(url)
+	assert.NoError(t, err, "Failed to get URL '%s'", url)
+	defer resp.Body.Close()
+
+	// THEN
+	// The response should be successful
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// The response body should contain the templated string
+	bodyBytes, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	bodyString := string(bodyBytes)
+	assert.NotContains(t, bodyString, "{{.settings.update.title}}")
+	assert.Contains(t, bodyString, "Schedule for updating (Playlist, XMLTV, Backup)")
 }


### PR DESCRIPTION
The web UI was displaying raw template placeholders (e.g., {{.settings.category.general}}) instead of the translated strings.

This was caused by an incorrect handler for JavaScript files in `src/webserver.go` that was serving them as static assets without processing them through the template engine.

The template placeholders are located within strings in the TypeScript files, which are then compiled to JavaScript. These JavaScript files are responsible for dynamically building the UI. Therefore, they must be parsed by the Go template engine on the server before being sent to the client.

This commit fixes the issue by:
1. Removing the special `.js` file handler that was bypassing the template engine.
2. Modifying the static file handler to also exclude `.js` files, allowing them to fall through to the template parsing logic.

This ensures that the localization strings are correctly injected into the JavaScript files before they are served, fixing the UI display issue.