### PR TITLE
fix(buffer): Include latest segment in HLS playlist

### DIFF
--- a/src/buffer.go
+++ b/src/buffer.go
@@ -369,7 +369,6 @@ func getBufTmpFiles(stream *ThisStream) (tmpFiles []string) {
 			}
 
 			sort.Float64s(fileIDs)
-			fileIDs = fileIDs[:len(fileIDs)-1]
 
 			for _, file := range fileIDs {
 				var fileName = fmt.Sprintf("%d.ts", int64(file))

--- a/src/buffer_test.go
+++ b/src/buffer_test.go
@@ -104,7 +104,11 @@ func TestGetBufTmpFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test directory: %v", err)
 	}
-	defer bufferVFS.RemoveAll(stream.Folder)
+	defer func() {
+		if err := bufferVFS.RemoveAll(stream.Folder); err != nil {
+			t.Logf("Error removing test directory %s: %v", stream.Folder, err)
+		}
+	}()
 
 	// Create dummy segment files
 	dummyFiles := []string{"1.ts", "2.ts", "3.ts"}

--- a/src/buffer_test.go
+++ b/src/buffer_test.go
@@ -90,3 +90,43 @@ func TestConnectWithRetry(t *testing.T) {
 		}
 	})
 }
+
+func TestGetBufTmpFiles(t *testing.T) {
+	// Initialize the in-memory filesystem for the test
+	initBufferVFS(true)
+
+	// Setup a dummy stream and directory
+	stream := &ThisStream{
+		Folder:      "/tmp/stream1/",
+		OldSegments: []string{},
+	}
+	err := bufferVFS.MkdirAll(stream.Folder, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create test directory: %v", err)
+	}
+	defer bufferVFS.RemoveAll(stream.Folder)
+
+	// Create dummy segment files
+	dummyFiles := []string{"1.ts", "2.ts", "3.ts"}
+	for _, fname := range dummyFiles {
+		file, err := bufferVFS.Create(stream.Folder + fname)
+		if err != nil {
+			t.Fatalf("Failed to create dummy file %s: %v", fname, err)
+		}
+		file.Close()
+	}
+
+	// Call the function to test
+	tmpFiles := getBufTmpFiles(stream)
+
+	// The function should return all available segment files.
+	if len(tmpFiles) != len(dummyFiles) {
+		t.Fatalf("Expected %d files, but got %d", len(dummyFiles), len(tmpFiles))
+	}
+
+	for i, f := range tmpFiles {
+		if f != dummyFiles[i] {
+			t.Errorf("Expected file %s at index %d, but got %s", dummyFiles[i], i, f)
+		}
+	}
+}


### PR DESCRIPTION
The `getBufTmpFiles` function was excluding the last (most recent) segment from the list of buffered files. This caused the HLS playlist (M3U8) to always be one segment behind what was available, leading to client players timing out and disconnecting.

This commit removes the line that excludes the last segment, ensuring the playlist is up-to-date.

A unit test has been added to verify the corrected behavior.