### PR TITLE
Fix(buffer): Resolve infinite loop in streaming

### DIFF
--- a/src/struct-buffer.go
+++ b/src/struct-buffer.go
@@ -64,6 +64,9 @@ type ThisStream struct {
 
 	// Local Temp Files
 	OldSegments []string
+
+	// Stream Status
+	StreamFinished bool
 }
 
 // Segment : URL Segments (HLS / M3U8)


### PR DESCRIPTION
This commit fixes a bug where the streaming buffer would enter an infinite loop when a stream ended, causing client connections to time out.

The fix involves two main changes:

1.  An "end-of-stream" signal (`StreamFinished`) has been added to the `ThisStream` struct. The downloading goroutine now sets this flag upon reaching the end of the source stream (`io.EOF`).

2.  The client-serving goroutine (`bufferingStream`) now checks for this `StreamFinished` flag. If the flag is set and there are no more buffered segments to send, it gracefully exits its loop and closes the client connection.

Additionally, the logic for tracking sent segments has been corrected to properly update the `OldSegments` slice, and a bug preventing streams smaller than the buffer size from being processed has been fixed.

A new unit test has been added to replicate the timeout issue and verify that the connection is now correctly closed when a stream ends.