### PR TITLE
fix(buffer): Exit download loop for non-HLS streams

### DIFF
--- a/cmd/e2e-streaming-test/main.go
+++ b/cmd/e2e-streaming-test/main.go
@@ -177,15 +177,14 @@ func runTests() error {
 		return fmt.Errorf("failed to add M3U playlist: %w", err)
 	}
 
-	// FIXME: The buffered test is disabled because it causes timeouts in the execution environment.
-	// // Run with buffer enabled
-	// if err := setBuffer(conn, "xteve", 1024); err != nil {
-	// 	return err
-	// }
-	// if err := runStreamingTest(conn); err != nil {
-	// 	return fmt.Errorf("streaming test failed with buffer enabled: %w", err)
-	// }
-	// fmt.Println("---")
+	// Run with buffer enabled
+	if err := setBuffer(conn, "xteve", 1024); err != nil {
+		return err
+	}
+	if err := runStreamingTest(conn); err != nil {
+		return fmt.Errorf("streaming test failed with buffer enabled: %w", err)
+	}
+	fmt.Println("---")
 
 	// Run with buffer disabled
 	if err := setBuffer(conn, "-", 0); err != nil {

--- a/src/buffer.go
+++ b/src/buffer.go
@@ -602,11 +602,10 @@ func connectToStreamingServer(streamID int, playlistID string) {
 				ShowError(err, 0)
 				addErrorToStream(err)
 				if resp != nil {
-					defer resp.Body.Close()
+					resp.Body.Close()
 				}
 				return
 			}
-			defer resp.Body.Close()
 
 			// Check HTTP Status, in case of errors the stream is terminated
 			var contentType = resp.Header.Get("Content-Type")
@@ -847,6 +846,10 @@ func connectToStreamingServer(streamID int, playlistID string) {
 			}
 
 			s++
+
+			if stream.StreamFinished && !stream.HLS {
+				return
+			}
 
 			// Calculate the waiting time for the Download of the next Segment
 			if stream.HLS {


### PR DESCRIPTION
The `connectToStreamingServer` function did not correctly exit the download loop for non-HLS streams after the stream had been completely buffered. This caused the function to repeatedly download the stream, resulting in excessive data usage and test failures.

This commit fixes the issue by adding a check to exit the loop when a non-HLS stream has finished downloading.

Additionally, a redundant `defer resp.Body.Close()` was removed to prevent a potential resource leak.