### PR TITLE
feat(e2e): Add client disconnect test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,7 @@ src/html/js/
 bin/
 node_modules/
 test-results/
+
+# E2E test binaries
 streamer_binary
+e2e-streaming-test


### PR DESCRIPTION
Adds an end-to-end test to verify that xteve disconnects from the source stream when the client disconnects prematurely.

This is tested for both buffered and unbuffered streaming.

The test works by:
1. Modifying the test streamer to track active connections.
2. Creating a new test case that starts a stream, reads a small amount of data, and then closes the connection.
3. Polling the streamer to ensure that the connection from xteve is terminated within a reasonable time.