### PR TITLE
Fix race condition in stream buffer for multiple clients

### DIFF
--- a/src/struct-buffer.go
+++ b/src/struct-buffer.go
@@ -64,10 +64,16 @@ type ThisStream struct {
 
 	// Local Temp Files
 	OldSegments       []string
-	CompletedSegments []string
+	CompletedSegments []SegmentInfo
 
 	// Stream Status
 	StreamFinished bool
+}
+
+// SegmentInfo : Holds buffer segment information
+type SegmentInfo struct {
+	Filename  string
+	SentCount int
 }
 
 // Segment : URL Segments (HLS / M3U8)


### PR DESCRIPTION
The previous implementation of the stream buffer had a race condition that caused issues when multiple clients connected to the same stream. The list of completed segments was cleared after being read by one client, causing other clients to stall and disconnect.

This change refactors the buffering logic to correctly support multiple clients:

- The `CompletedSegments` data structure in `ThisStream` is changed from a simple slice of strings to a slice of `SegmentInfo` structs. Each struct tracks the filename and a `SentCount`.
- The `bufferingStream` function is updated to use this new structure. Each client now tracks the segments it has sent locally and updates the shared `SentCount` in a thread-safe manner.
- A cleanup mechanism is introduced to remove segments from the buffer once they have been sent to all connected clients, preventing memory leaks.