### PR TITLE
docs: Update agent instructions for sudo usage

### DIFF
--- a/.jules-agent.yaml
+++ b/.jules-agent.yaml
@@ -1,0 +1,12 @@
+# Instructions for Jules, the AI software engineer.
+---
+environment_setup:
+  - "When creating a new VM, run `make build` and fix dependency issues until it passes. This ensures the development environment is ready."
+  - "Always use `sudo` when running `apt-get` commands for package installation or system updates."
+
+testing:
+  - "For any new code, a test should be created for that code."
+  - "If fixing a bug, first build a test that proves you've found the bug. Then fix it. Then verify your new test passes."
+
+code_quality:
+  - "Prioritize code readability and maintainability."

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ The following steps will create the `xteve`, `xteve-inactive`, and `xteve-status
    npm install
    ```
 
-3. **Run the build script:**
+3. **Run the build command:**
    ```sh
-   sh build.sh
+   make build
    ```
 
 To enable this feature, go to `Settings -> Streaming` and check the `Enable Stream Retry` box. You can also configure the maximum number of retries and the delay between retries.


### PR DESCRIPTION
Adds a new instruction to `.jules-agent.yaml` to always use `sudo` when running `apt-get` commands. This ensures that the agent has the necessary permissions for package management tasks.