### PR TITLE
Refactor: Replace unsafe type assertions with safe checks

### DIFF
--- a/cmd/e2e-streaming-test/main.go
+++ b/cmd/e2e-streaming-test/main.go
@@ -244,8 +244,12 @@ func verifyTunerCountIsZero() error {
 	}
 
 	if tunerActive, ok := responseMap["tuners.active"]; ok {
-		if tunerActive.(float64) != 0 {
-			return fmt.Errorf("expected active tuner count to be 0, but got %v", tunerActive)
+		if ta, ok := tunerActive.(float64); ok {
+			if ta != 0 {
+				return fmt.Errorf("expected active tuner count to be 0, but got %v", tunerActive)
+			}
+		} else {
+			return fmt.Errorf("invalid type for tuners.active: expected float64, got %T", tunerActive)
 		}
 	} else {
 		// If the key doesn't exist, it means the count is 0 because of omitempty

--- a/src/backup.go
+++ b/src/backup.go
@@ -143,7 +143,13 @@ func xteveRestore(archive string) (newWebURL string, err error) {
 		return
 	}
 
-	backupVersion = newConfig["version"].(string)
+	if bv, ok := newConfig["version"].(string); ok {
+		backupVersion = bv
+	} else {
+		err = errors.New("backup version not found in settings.json")
+		return
+	}
+
 	if backupVersion < System.Compatibility {
 		err = errors.New(getErrMsg(1013))
 		return
@@ -167,7 +173,12 @@ func xteveRestore(archive string) (newWebURL string, err error) {
 		return
 	}
 
-	newPort = newConfig["port"].(string)
+	if np, ok := newConfig["port"].(string); ok {
+		newPort = np
+	} else {
+		err = errors.New("port not found in settings.json")
+		return
+	}
 	oldPort = Settings.Port
 
 	if newPort == oldPort {

--- a/src/buffer_test.go
+++ b/src/buffer_test.go
@@ -261,8 +261,12 @@ func TestTunerCountOnDisconnect(t *testing.T) {
 
 	// Verify initial state
 	p, _ := BufferInformation.Load(playlistID)
-	if len(p.(Playlist).Streams) != 1 {
-		t.Fatalf("Initial stream count should be 1, but was %d", len(p.(Playlist).Streams))
+	if playlist, ok := p.(Playlist); ok {
+		if len(playlist.Streams) != 1 {
+			t.Fatalf("Initial stream count should be 1, but was %d", len(playlist.Streams))
+		}
+	} else {
+		t.Fatalf("Failed to cast to Playlist")
 	}
 
 	// 2. Action: Simulate client disconnect
@@ -276,9 +280,12 @@ func TestTunerCountOnDisconnect(t *testing.T) {
 		return
 	}
 
-	finalPlaylist := p.(Playlist)
-	if len(finalPlaylist.Streams) != 0 {
-		t.Errorf("Expected stream count to be 0 after disconnect, but was %d", len(finalPlaylist.Streams))
+	if finalPlaylist, ok := p.(Playlist); ok {
+		if len(finalPlaylist.Streams) != 0 {
+			t.Errorf("Expected stream count to be 0 after disconnect, but was %d", len(finalPlaylist.Streams))
+		}
+	} else {
+		t.Fatalf("Failed to cast to Playlist")
 	}
 
 	_, clientExists := BufferClients.Load(playlistID + md5)

--- a/src/m3u.go
+++ b/src/m3u.go
@@ -183,7 +183,10 @@ func buildM3U(groups []string) (m3u string, err error) {
 	switch Settings.EpgSource {
 	case "PMS":
 		for i, dsa := range Data.Streams.Active {
-			var stream = dsa.(map[string]string)
+			var stream, ok = dsa.(map[string]string)
+			if !ok {
+				continue
+			}
 			var channel XEPGChannelStruct
 
 			channel.XName = stream["name"]

--- a/src/system.go
+++ b/src/system.go
@@ -27,7 +27,10 @@ func createSystemFolders() (err error) {
 	e := reflect.ValueOf(&System.Folder).Elem()
 
 	for i := range e.NumField() {
-		var folder = e.Field(i).Interface().(string)
+		var folder, ok = e.Field(i).Interface().(string)
+		if !ok {
+			continue
+		}
 		err = checkFolder(folder)
 		if err != nil {
 			return

--- a/src/update.go
+++ b/src/update.go
@@ -122,7 +122,9 @@ func convertToNewFilter(oldFilter []any) (newFilterMap map[int]any) {
 			var newFilter FilterStruct
 			newFilter.Active = true
 			newFilter.Name = fmt.Sprintf("Custom filter %d", i+1)
-			newFilter.Filter = s.Index(i).Interface().(string)
+			if filter, ok := s.Index(i).Interface().(string); ok {
+				newFilter.Filter = filter
+			}
 			newFilter.Type = "custom-filter"
 			newFilter.CaseSensitive = false
 
@@ -136,7 +138,10 @@ func setValueForUUID() (err error) {
 	xepg, _ := loadJSONFileToMap(System.File.XEPG)
 
 	for _, c := range xepg {
-		var xepgChannel = c.(map[string]any)
+		var xepgChannel, ok = c.(map[string]any)
+		if !ok {
+			continue
+		}
 
 		if uuidKey, ok := xepgChannel["_uuid.key"].(string); ok {
 			if value, ok := xepgChannel[uuidKey].(string); ok {

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -966,9 +966,10 @@ func API(w http.ResponseWriter, r *http.Request) {
 		response.URLXepg = System.ServerProtocol.XML + "://" + System.Domain + "/xmltv/xteve.xml"
 
 		BufferInformation.Range(func(k, v any) bool {
-			playlist := v.(Playlist)
-			response.TunerActive += int64(len(playlist.Streams))
-			response.TunerAll += int64(playlist.Tuner)
+			if playlist, ok := v.(Playlist); ok {
+				response.TunerActive += int64(len(playlist.Streams))
+				response.TunerAll += int64(playlist.Tuner)
+			}
 			return true
 		})
 	case "update.m3u":

--- a/src/xepg.go
+++ b/src/xepg.go
@@ -216,7 +216,9 @@ func createXEPGMapping() {
 		dummyChannel["display-names"] = []DisplayName{{Value: i + " Minutes"}}
 		dummyChannel["id"] = i + "_Minutes"
 		dummyChannel["icon"] = ""
-		dummy[dummyChannel["id"].(string)] = dummyChannel
+		if id, ok := dummyChannel["id"].(string); ok {
+			dummy[id] = dummyChannel
+		}
 	}
 	Data.XMLTV.Mapping["xTeVe Dummy"] = dummy
 }
@@ -619,16 +621,18 @@ func performAutomaticChannelMapping(xepgChannel XEPGChannelStruct, _ string) (XE
 						xepgNameSolid := strings.ReplaceAll(xepgChannel.Name, " ", "")
 
 						if strings.EqualFold(xmltvNameSolid, xepgNameSolid) {
-							xepgChannel.XmltvFile = file
-							xepgChannel.XMapping = channelData["id"].(string)
-							mappingMade = true
-							if icon, ok := channelData["icon"].(string); ok {
-								if len(icon) > 0 {
-									xepgChannel.TvgLogo = icon
+							if id, ok := channelData["id"].(string); ok {
+								xepgChannel.XmltvFile = file
+								xepgChannel.XMapping = id
+								mappingMade = true
+								if icon, ok := channelData["icon"].(string); ok {
+									if len(icon) > 0 {
+										xepgChannel.TvgLogo = icon
+									}
 								}
+								mappingFound = true // Set flag to break outer and inner loops
+								break               // Break from inner loop over displayNamesArray
 							}
-							mappingFound = true // Set flag to break outer and inner loops
-							break               // Break from inner loop over displayNamesArray
 						}
 					}
 					// if mappingFound, the inner loop over xmltvMap will break in next iter


### PR DESCRIPTION
This commit replaces all unsafe type assertions in the codebase with the safe "comma ok" idiom. This prevents potential panics when casting interface{} types to concrete types.

The changes include:
- Replacing `variable.(Type)` with `v, ok := variable.(Type)`
- Adding error handling or control flow to handle failed assertions gracefully
- Applying these changes to all relevant files in the codebase