### PR TITLE
feat(testing): add e2e tests for status and inactive commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ test-results/
 # E2E test binaries
 streamer_binary
 e2e-streaming-test
+xteve-status
+xteve-inactive


### PR DESCRIPTION
This commit enhances the end-to-end streaming tests to include checks for the `xteve-status` and `xteve-inactive` commands.

The following checks are added:

- `xteve-status` is tested when xTeVe is running and when it is not.
- `xteve-inactive` is tested when xTeVe is running with an active stream, without an active stream, and when it is not running.

This ensures that these commands are working as expected and improves the overall test coverage of the application.