### PR TITLE
fix(streaming): remove redundant tuner logging

### DIFF
--- a/src/buffer.go
+++ b/src/buffer.go
@@ -411,15 +411,8 @@ func clientConnection(stream ThisStream) (status bool) {
 			ShowError(err, 4005)
 		}
 
-		if p, ok := BufferInformation.Load(stream.PlaylistID); ok {
+		if _, ok := BufferInformation.Load(stream.PlaylistID); ok {
 			showInfo(fmt.Sprintf("Streaming Status:Channel: %s - No client is using this channel anymore. Streaming Server connection has ended", stream.ChannelName))
-
-			if playlist, ok := p.(Playlist); ok {
-				showInfo(fmt.Sprintf("Streaming Status:Playlist: %s - Tuner: %d / %d", playlist.PlaylistName, len(playlist.Streams), playlist.Tuner))
-				if len(playlist.Streams) <= 0 {
-					BufferInformation.Delete(stream.PlaylistID)
-				}
-			}
 		}
 		status = false
 	}


### PR DESCRIPTION
Removes redundant tuner status logging from the `clientConnection` function. This prevents incorrect tuner counts from being logged when a stream disconnects.

When a client disconnects, `killClientConnection` is responsible for updating the tuner count. However, the `clientConnection` function, which runs in a separate goroutine to download the stream, also logged the tuner status. This could lead to a race condition where `clientConnection` would log the tuner count after `killClientConnection` had already modified the state, resulting in confusing and incorrect log messages.

This change makes `killClientConnection` the single source of truth for tuner status upon client disconnection, resolving the issue.