### PR TITLE
refactor(buffer): make stream reservation atomic

### DIFF
--- a/src/buffer.go
+++ b/src/buffer.go
@@ -79,6 +79,11 @@ func reserveStreamSlot(playlistID, streamingURL, channelName string) (*Playlist,
 		stream.URL = streamingURL
 		stream.ChannelName = channelName
 		stream.Status = false
+		// Populated from updateStreamWithMetadata
+		stream.MD5 = getMD5(streamingURL)
+		stream.Folder = playlist.Folder + stream.MD5 + string(os.PathSeparator)
+		stream.PlaylistID = playlistID
+		stream.PlaylistName = playlist.PlaylistName
 
 		playlist.Streams[streamID] = stream
 		playlist.Clients[streamID] = client
@@ -129,6 +134,11 @@ func reserveStreamSlot(playlistID, streamingURL, channelName string) (*Playlist,
 			stream.URL = streamingURL
 			stream.ChannelName = channelName
 			stream.Status = false
+			// Populated from updateStreamWithMetadata
+			stream.MD5 = getMD5(streamingURL)
+			stream.Folder = playlist.Folder + stream.MD5 + string(os.PathSeparator)
+			stream.PlaylistID = playlistID
+			stream.PlaylistName = playlist.PlaylistName
 
 			playlist.Streams[streamID] = stream
 			playlist.Clients[streamID] = client
@@ -136,39 +146,6 @@ func reserveStreamSlot(playlistID, streamingURL, channelName string) (*Playlist,
 	}
 
 	return playlist, stream, client, streamID, newStream, nil
-}
-
-// updateStreamWithMetadata adds required metadata to a newly created stream entry.
-// It uses a lock to ensure the update is atomic and doesn't cause race conditions.
-func updateStreamWithMetadata(playlistID string, streamID int, streamingURL string) {
-	Lock.Lock()
-	defer Lock.Unlock()
-
-	// It's possible the playlist or stream was deleted between reserveStreamSlot and now.
-	// We need to load the fresh playlist state to be sure.
-	currentP, ok := BufferInformation.Load(playlistID)
-	if !ok {
-		return // Playlist was deleted.
-	}
-	playlist, ok := currentP.(*Playlist)
-	if !ok {
-		return // Should not happen.
-	}
-
-	stream, streamExists := playlist.Streams[streamID]
-	if !streamExists {
-		return // Stream was deleted.
-	}
-
-	// Add metadata
-	stream.MD5 = getMD5(streamingURL)
-	stream.Folder = playlist.Folder + stream.MD5 + string(os.PathSeparator)
-	stream.PlaylistID = playlistID
-	stream.PlaylistName = playlist.PlaylistName // Note: playlist.PlaylistName comes from the fresh copy
-
-	// Put the updated stream back and store the playlist
-	playlist.Streams[streamID] = stream
-	BufferInformation.Store(playlistID, playlist)
 }
 
 func bufferingStream(playlistID, streamingURL, channelName string, w http.ResponseWriter, r *http.Request) {
@@ -213,20 +190,7 @@ func bufferingStream(playlistID, streamingURL, channelName string, w http.Respon
 	// Check whether the Stream is already being played by another Client
 	if !playlist.Streams[streamID].Status && newStream {
 		// New buffer is required.
-		// The stream entry is created in reserveStreamSlot, but we need to add metadata to it.
-		// This must be done atomically to avoid race conditions.
-		updateStreamWithMetadata(playlistID, streamID, streamingURL)
-
-		// Get the fresh playlist state to access the stream with the MD5 hash
-		if p, ok := BufferInformation.Load(playlistID); ok {
-			if pl, ok := p.(*Playlist); ok {
-				playlist = pl
-			} else {
-				return
-			}
-		}
-		stream = playlist.Streams[streamID] // This stream now has the MD5
-
+		// The stream entry is now created atomically in reserveStreamSlot.
 		var clients ClientConnection
 		clients.Connection = 1
 		BufferClients.Store(playlistID+stream.MD5, &clients)


### PR DESCRIPTION
Consolidated the logic for stream reservation and metadata population into a single function, `reserveStreamSlot`. This makes the creation of a new stream an atomic operation protected by a single lock.

Previously, the logic was split between `reserveStreamSlot` and `updateStreamWithMetadata`, each with its own lock. This could lead to race conditions and inefficient locking, causing connection delays and timeouts as described by users.

By making this operation atomic, we prevent potential race conditions and reduce lock contention, improving the reliability and performance of stream startup.