### PR TITLE
feat: Add MPEG-TS parser for stream buffering

### DIFF
--- a/cmd/e2e-streaming-test/main.go
+++ b/cmd/e2e-streaming-test/main.go
@@ -446,20 +446,30 @@ func runMultiStreamTest(streamURLs []string, numStreams int, buffered bool) erro
 		}(i+1, streamURLs[i])
 	}
 
+	var tunerCheckWg sync.WaitGroup
+	if buffered {
+		tunerCheckWg.Add(1)
+		go func() {
+			defer tunerCheckWg.Done()
+			time.Sleep(5 * time.Second) // Wait for streams to be active
+			activeTuners, err := getActiveTunerCount()
+			if err != nil {
+				errs <- fmt.Errorf("failed to get active tuner count: %w", err)
+				return
+			}
+			if activeTuners != numStreams {
+				errs <- fmt.Errorf("expected %d active tuners, but got %d", numStreams, activeTuners)
+				return
+			}
+			fmt.Printf("Verified %d active tuners.\n", activeTuners)
+		}()
+	}
+
 	wg.Wait()
 	close(errs)
 
 	if buffered {
-		// Give the server a moment to update state
-		time.Sleep(2 * time.Second)
-		activeTuners, err := getActiveTunerCount()
-		if err != nil {
-			return fmt.Errorf("failed to get active tuner count: %w", err)
-		}
-		if activeTuners != numStreams {
-			return fmt.Errorf("expected %d active tuners, but got %d", numStreams, activeTuners)
-		}
-		fmt.Printf("Verified %d active tuners.\n", activeTuners)
+		tunerCheckWg.Wait()
 	}
 
 	var combinedErr error
@@ -480,16 +490,24 @@ func runMultiStreamTest(streamURLs []string, numStreams int, buffered bool) erro
 }
 
 func verifyStreamedData(data []byte, streamID int) error {
-	expectedSize := streamSize
+	expectedSize := (streamSize / 188) * 188
 	if len(data) != expectedSize {
 		return fmt.Errorf("streamed data size mismatch. Expected: %d, got: %d", expectedSize, len(data))
 	}
-	for i, b := range data {
-		expectedByte := byte((i + streamID - 1) % 256)
-		if b != expectedByte {
-			return fmt.Errorf("streamed data content mismatch at byte %d. Expected: %d, got: %d", i, expectedByte, b)
+
+	for i := 0; i < len(data); i += 188 {
+		packet := data[i : i+188]
+		if packet[0] != 0x47 {
+			return fmt.Errorf("invalid sync byte at offset %d", i)
+		}
+		for j := 1; j < 188; j++ {
+			expectedByte := byte((i + j + streamID - 1) % 256)
+			if packet[j] != expectedByte {
+				return fmt.Errorf("streamed data content mismatch at byte %d. Expected: %d, got: %d", i+j, expectedByte, packet[j])
+			}
 		}
 	}
+
 	return nil
 }
 

--- a/src/buffer.go
+++ b/src/buffer.go
@@ -783,7 +783,12 @@ func handleTSStream(resp *http.Response, stream ThisStream, streamID int, playli
 
 		n, err := resp.Body.Read(buffer)
 		if n > 0 {
-			parser.Write(buffer[:n])
+			if _, err := parser.Write(buffer[:n]); err != nil {
+				ShowError(err, 0)
+				addErrorToStream(err)
+				bufferFile.Close()
+				return stream, err
+			}
 			for {
 				packet, err := parser.Next()
 				if err == io.EOF {

--- a/src/buffer.go
+++ b/src/buffer.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/avfs/avfs/vfs/memfs"
 	"github.com/avfs/avfs/vfs/osfs"
+	"xteve/src/mpegts"
 )
 
 var errTunerLimitReached = errors.New("tuner limit reached")
@@ -746,7 +747,6 @@ func handleHLSStream(resp *http.Response, stream ThisStream, tmpFolder string, t
 
 func handleTSStream(resp *http.Response, stream ThisStream, streamID int, playlistID, tmpFolder string, tmpSegment *int, addErrorToStream func(err error), buffer []byte, bandwidth *BandwidthCalculation, retries int) (ThisStream, error) {
 	var fileSize int
-	var bytesWritten int
 	var bufferSize = Settings.BufferSize
 	var tmpFileSize = 1024 * bufferSize * 1
 	var debug string
@@ -772,6 +772,8 @@ func handleTSStream(resp *http.Response, stream ThisStream, streamID int, playli
 		return stream, err
 	}
 
+	parser := mpegts.NewParser()
+
 	defer resp.Body.Close()
 	for {
 		if fileSize == 0 {
@@ -781,24 +783,27 @@ func handleTSStream(resp *http.Response, stream ThisStream, streamID int, playli
 
 		n, err := resp.Body.Read(buffer)
 		if n > 0 {
-			bytesWritten = 0
-			for bytesWritten < n {
-				// Calculate how much to write in this chunk
-				writeSize := n - bytesWritten
-				if fileSize+writeSize > tmpFileSize {
-					writeSize = tmpFileSize - fileSize
+			parser.Write(buffer[:n])
+			for {
+				packet, err := parser.Next()
+				if err == io.EOF {
+					break
 				}
-
-				if _, err := bufferFile.Write(buffer[bytesWritten : bytesWritten+writeSize]); err != nil {
+				if err != nil {
 					ShowError(err, 0)
 					addErrorToStream(err)
 					bufferFile.Close()
 					return stream, err
 				}
-				fileSize += writeSize
-				bytesWritten += writeSize
 
-				// If the file is full, create a new one
+				if _, err := bufferFile.Write(packet); err != nil {
+					ShowError(err, 0)
+					addErrorToStream(err)
+					bufferFile.Close()
+					return stream, err
+				}
+				fileSize += len(packet)
+
 				if fileSize >= tmpFileSize {
 					bufferFile.Close()
 					completeTSsegment(playlistID, streamID, &stream, bandwidth, fileSize, tmpFile, *tmpSegment)

--- a/src/buffer_handle_ts_stream_test.go
+++ b/src/buffer_handle_ts_stream_test.go
@@ -116,7 +116,7 @@ func TestHandleTSStream(t *testing.T) {
 	}
 
 	if !bytes.Equal(writtenContent, validTSStream.Bytes()) {
-		t.Errorf("Content of created file does not match expected content. Got %s, want %s", string(writtenContent), string(validTSStream.Bytes()))
+		t.Errorf("Content of created file does not match expected content. Got %s, want %s", string(writtenContent), validTSStream.String())
 	}
 }
 

--- a/src/buffer_handle_ts_stream_test.go
+++ b/src/buffer_handle_ts_stream_test.go
@@ -7,15 +7,23 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"xteve/src/mpegts"
 )
 
 func TestHandleTSStream(t *testing.T) {
 	// 1. Setup mock server
-	content := []byte("some ts stream data")
+	var validTSStream bytes.Buffer
+	packet1 := make([]byte, mpegts.PacketSize)
+	packet1[0] = mpegts.SyncByte
+	validTSStream.Write(packet1)
+	packet2 := make([]byte, mpegts.PacketSize)
+	packet2[0] = mpegts.SyncByte
+	validTSStream.Write(packet2)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "video/mp2t")
 		w.WriteHeader(http.StatusOK)
-		_, err := w.Write(content)
+		_, err := w.Write(validTSStream.Bytes())
 		if err != nil {
 			t.Logf("Error writing content in mock server: %v", err)
 		}
@@ -50,7 +58,7 @@ func TestHandleTSStream(t *testing.T) {
 
 	var clients ClientConnection
 	clients.Connection = 1
-	BufferClients.Store(playlistID+md5, clients)
+	BufferClients.Store(playlistID+md5, &clients)
 	defer BufferClients.Delete(playlistID + md5)
 
 	var tmpSegment = 1
@@ -107,7 +115,111 @@ func TestHandleTSStream(t *testing.T) {
 		t.Fatalf("Failed to read content of created file: %v", err)
 	}
 
-	if !bytes.Equal(writtenContent, content) {
-		t.Errorf("Content of created file does not match expected content. Got %s, want %s", string(writtenContent), string(content))
+	if !bytes.Equal(writtenContent, validTSStream.Bytes()) {
+		t.Errorf("Content of created file does not match expected content. Got %s, want %s", string(writtenContent), string(validTSStream.Bytes()))
+	}
+}
+
+func TestHandleTSStream_Corrupted(t *testing.T) {
+	// 1. Setup mock server with corrupted data
+	var corruptedTSStream bytes.Buffer
+	corruptedTSStream.Write([]byte{0x01, 0x02, 0x03}) // Garbage
+	packet1 := make([]byte, mpegts.PacketSize)
+	packet1[0] = mpegts.SyncByte
+	corruptedTSStream.Write(packet1)
+	corruptedTSStream.Write([]byte{0x04, 0x05, 0x06}) // More garbage
+	packet2 := make([]byte, mpegts.PacketSize)
+	packet2[0] = mpegts.SyncByte
+	corruptedTSStream.Write(packet2)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "video/mp2t")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(corruptedTSStream.Bytes())
+		if err != nil {
+			t.Logf("Error writing content in mock server: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	// 2. Setup VFS and other required state
+	initBufferVFS(true)
+	Settings.BufferSize = 1024 // 1MB buffer size
+	Settings.UserAgent = "xTeVe-Test"
+
+	playlistID := "M1"
+	streamID := 0
+	tmpFolder := "/tmp/xteve_test_ts_stream_corrupted/"
+	err := bufferVFS.MkdirAll(tmpFolder, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create test directory: %v", err)
+	}
+	defer func() {
+		if err := bufferVFS.RemoveAll(tmpFolder); err != nil {
+			t.Logf("Error removing test directory %s: %v", tmpFolder, err)
+		}
+	}()
+
+	md5 := getMD5(server.URL)
+	stream := ThisStream{
+		URL:        server.URL,
+		Folder:     tmpFolder,
+		PlaylistID: playlistID,
+		MD5:        md5,
+	}
+
+	var clients ClientConnection
+	clients.Connection = 1
+	BufferClients.Store(playlistID+md5, &clients)
+	defer BufferClients.Delete(playlistID + md5)
+
+	var tmpSegment = 1
+	var errors []error
+	addErrorToStream := func(err error) {
+		errors = append(errors, err)
+	}
+	var buffer = make([]byte, 1024*Settings.BufferSize)
+	var bandwidth BandwidthCalculation
+	var retries = 0
+
+	req, err := http.NewRequest("GET", server.URL, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Failed to make request to mock server: %v", err)
+	}
+
+	// 3. Call the function
+	_, err = handleTSStream(resp, stream, streamID, playlistID, tmpFolder, &tmpSegment, addErrorToStream, buffer, &bandwidth, retries)
+	if err != nil {
+		t.Fatalf("handleTSStream returned an error: %v", err)
+	}
+
+	// 4. Verify the results
+	if len(errors) > 0 {
+		t.Errorf("addErrorToStream was called with errors: %v", errors)
+	}
+
+	// Verify that the file was written to the VFS and contains only the valid packets
+	expectedFile := tmpFolder + "1.ts"
+	fileContent, err := bufferVFS.Open(expectedFile)
+	if err != nil {
+		t.Fatalf("Failed to open created file: %v", err)
+	}
+	defer fileContent.Close()
+
+	writtenContent, err := io.ReadAll(fileContent)
+	if err != nil {
+		t.Fatalf("Failed to read content of created file: %v", err)
+	}
+
+	var expectedContent bytes.Buffer
+	expectedContent.Write(packet1)
+	expectedContent.Write(packet2)
+
+	if !bytes.Equal(writtenContent, expectedContent.Bytes()) {
+		t.Errorf("Content of created file does not match expected content. Got %d bytes, want %d bytes", len(writtenContent), len(expectedContent.Bytes()))
 	}
 }

--- a/src/buffer_test.go
+++ b/src/buffer_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"testing"
 	"time"
+	"xteve/src/mpegts"
 )
 
 func TestConnectWithRetry(t *testing.T) {
@@ -97,14 +98,13 @@ func TestConnectWithRetry(t *testing.T) {
 func TestConnectToStreamingServer_Buffering(t *testing.T) {
 	// 1. Setup mock server
 	// Create 10MB of valid MPEG-TS data
-	packetSize := 188
-	numPackets := (10 * 1024 * 1024) / packetSize
-	content := make([]byte, numPackets*packetSize)
+	numPackets := (10 * 1024 * 1024) / mpegts.PacketSize
+	content := make([]byte, numPackets*mpegts.PacketSize)
 	for i := 0; i < numPackets; i++ {
-		offset := i * packetSize
-		packet := content[offset : offset+packetSize]
-		packet[0] = 0x47 // Sync byte
-		for j := 1; j < packetSize; j++ {
+		offset := i * mpegts.PacketSize
+		packet := content[offset : offset+mpegts.PacketSize]
+		packet[0] = mpegts.SyncByte
+		for j := 1; j < mpegts.PacketSize; j++ {
 			packet[j] = byte((offset + j) % 256)
 		}
 	}
@@ -477,13 +477,12 @@ func TestTunerCountOnDisconnect(t *testing.T) {
 
 func TestBufferingStream_ClosesOnStreamEnd(t *testing.T) {
 	// 1. Setup mock server that serves a small amount of data and then closes
-	packetSize := 188
 	numPackets := 10
-	content := make([]byte, numPackets*packetSize)
+	content := make([]byte, numPackets*mpegts.PacketSize)
 	for i := 0; i < numPackets; i++ {
-		offset := i * packetSize
-		packet := content[offset : offset+packetSize]
-		packet[0] = 0x47 // Sync byte
+		offset := i * mpegts.PacketSize
+		packet := content[offset : offset+mpegts.PacketSize]
+		packet[0] = mpegts.SyncByte
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/mpegts/parser.go
+++ b/src/mpegts/parser.go
@@ -32,31 +32,29 @@ func (p *Parser) Write(data []byte) (int, error) {
 // Next returns the next valid MPEG-TS packet from the buffer.
 // If no packet is available, it returns io.EOF.
 func (p *Parser) Next() ([]byte, error) {
-	for {
-		// Find the sync byte.
-		idx := bytes.IndexByte(p.buf.Bytes(), SyncByte)
-		if idx == -1 {
-			// No sync byte found, so we can't find a packet.
-			// We can discard the entire buffer.
-			p.buf.Reset()
-			return nil, io.EOF
-		}
-
-		// Discard any data before the sync byte.
-		if idx > 0 {
-			p.buf.Next(idx)
-		}
-
-		// Check if we have a full packet.
-		if p.buf.Len() < PacketSize {
-			return nil, io.EOF
-		}
-
-		packet := make([]byte, PacketSize)
-		if _, err := p.buf.Read(packet); err != nil {
-			return nil, err
-		}
-
-		return packet, nil
+	// Find the sync byte.
+	idx := bytes.IndexByte(p.buf.Bytes(), SyncByte)
+	if idx == -1 {
+		// No sync byte found, so we can't find a packet.
+		// We can discard the entire buffer.
+		p.buf.Reset()
+		return nil, io.EOF
 	}
+
+	// Discard any data before the sync byte.
+	if idx > 0 {
+		p.buf.Next(idx)
+	}
+
+	// Check if we have a full packet.
+	if p.buf.Len() < PacketSize {
+		return nil, io.EOF
+	}
+
+	packet := make([]byte, PacketSize)
+	if _, err := p.buf.Read(packet); err != nil {
+		return nil, err
+	}
+
+	return packet, nil
 }

--- a/src/mpegts/parser.go
+++ b/src/mpegts/parser.go
@@ -1,0 +1,62 @@
+package mpegts
+
+import (
+	"bytes"
+	"io"
+)
+
+const (
+	// PacketSize is the size of a single MPEG-TS packet.
+	PacketSize = 188
+	// SyncByte is the sync byte that marks the start of a packet.
+	SyncByte = 0x47
+)
+
+// Parser is a parser for MPEG-TS streams.
+type Parser struct {
+	buf *bytes.Buffer
+}
+
+// NewParser creates a new MPEG-TS parser.
+func NewParser() *Parser {
+	return &Parser{
+		buf: &bytes.Buffer{},
+	}
+}
+
+// Write appends the given data to the parser's buffer.
+func (p *Parser) Write(data []byte) (int, error) {
+	return p.buf.Write(data)
+}
+
+// Next returns the next valid MPEG-TS packet from the buffer.
+// If no packet is available, it returns io.EOF.
+func (p *Parser) Next() ([]byte, error) {
+	for {
+		// Find the sync byte.
+		idx := bytes.IndexByte(p.buf.Bytes(), SyncByte)
+		if idx == -1 {
+			// No sync byte found, so we can't find a packet.
+			// We can discard the entire buffer.
+			p.buf.Reset()
+			return nil, io.EOF
+		}
+
+		// Discard any data before the sync byte.
+		if idx > 0 {
+			p.buf.Next(idx)
+		}
+
+		// Check if we have a full packet.
+		if p.buf.Len() < PacketSize {
+			return nil, io.EOF
+		}
+
+		packet := make([]byte, PacketSize)
+		if _, err := p.buf.Read(packet); err != nil {
+			return nil, err
+		}
+
+		return packet, nil
+	}
+}

--- a/src/mpegts/parser_test.go
+++ b/src/mpegts/parser_test.go
@@ -20,7 +20,9 @@ func TestParser_Next_ValidStream(t *testing.T) {
 	buf.Write(packet2)
 
 	parser := NewParser()
-	parser.Write(buf.Bytes())
+	if _, err := parser.Write(buf.Bytes()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// First packet
 	p, err := parser.Next()
@@ -70,7 +72,9 @@ func TestParser_Next_CorruptedStream(t *testing.T) {
 	buf.Write(packet3)
 
 	parser := NewParser()
-	parser.Write(buf.Bytes())
+	if _, err := parser.Write(buf.Bytes()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// First packet
 	p, err := parser.Next()

--- a/src/mpegts/parser_test.go
+++ b/src/mpegts/parser_test.go
@@ -1,0 +1,107 @@
+package mpegts
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestParser_Next_ValidStream(t *testing.T) {
+	// Create a buffer with two valid packets.
+	var buf bytes.Buffer
+	packet1 := make([]byte, PacketSize)
+	packet1[0] = SyncByte
+	packet1[1] = 0x11
+	buf.Write(packet1)
+
+	packet2 := make([]byte, PacketSize)
+	packet2[0] = SyncByte
+	packet2[1] = 0x22
+	buf.Write(packet2)
+
+	parser := NewParser()
+	parser.Write(buf.Bytes())
+
+	// First packet
+	p, err := parser.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(p, packet1) {
+		t.Errorf("expected packet %v, got %v", packet1, p)
+	}
+
+	// Second packet
+	p, err = parser.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(p, packet2) {
+		t.Errorf("expected packet %v, got %v", packet2, p)
+	}
+
+	// No more packets
+	_, err = parser.Next()
+	if err != io.EOF {
+		t.Errorf("expected io.EOF, got %v", err)
+	}
+}
+
+func TestParser_Next_CorruptedStream(t *testing.T) {
+	// Create a buffer with garbage data and three valid packets.
+	var buf bytes.Buffer
+	buf.Write([]byte{0x01, 0x02, 0x03}) // Garbage
+
+	packet1 := make([]byte, PacketSize)
+	packet1[0] = SyncByte
+	packet1[1] = 0x11
+	buf.Write(packet1)
+
+	buf.Write([]byte{0x04, 0x05, 0x06}) // More garbage
+
+	packet2 := make([]byte, PacketSize)
+	packet2[0] = SyncByte
+	packet2[1] = 0x22
+	buf.Write(packet2)
+
+	packet3 := make([]byte, PacketSize)
+	packet3[0] = SyncByte
+	packet3[1] = 0x33
+	buf.Write(packet3)
+
+	parser := NewParser()
+	parser.Write(buf.Bytes())
+
+	// First packet
+	p, err := parser.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(p, packet1) {
+		t.Errorf("expected packet %v, got %v", packet1, p)
+	}
+
+	// Second packet
+	p, err = parser.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(p, packet2) {
+		t.Errorf("expected packet %v, got %v", packet2, p)
+	}
+
+	// Third packet
+	p, err = parser.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(p, packet3) {
+		t.Errorf("expected packet %v, got %v", packet3, p)
+	}
+
+	// No more packets
+	_, err = parser.Next()
+	if err != io.EOF {
+		t.Errorf("expected io.EOF, got %v", err)
+	}
+}


### PR DESCRIPTION
This change introduces a new MPEG-TS parser that validates incoming transport stream packets before they are written to the buffer. The parser scans for the 0x47 sync byte and ensures that only valid 188-byte packets are buffered. This prevents corrupted data from being written to the buffer and improves the stability of the streaming service.

The E2E streaming tests have been updated to use valid MPEG-TS streams, and a new test has been added to verify that the parser can recover from corrupted streams.