### PR TITLE
feat: Make JS and video builds incremental

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,16 @@ BINDIR = bin
 # Default target
 all: build
 
+# TypeScript variables
+TS_SRC = $(wildcard ts/*.ts)
+JS_DIR = src/html/js
+
+# Video variables
+VIDEO_SRC = src/html/img/stream-limit.jpg
+VIDEO_TARGET = src/html/video/stream-limit.bin
+
 # Build targets
-build: ts-compile generate-video
+build: $(JS_DIR) $(VIDEO_TARGET)
 	@echo "--- Building Go commands ---"
 	@mkdir -p $(BINDIR)
 	$(GOCMD) -o ./$(BINDIR)/xteve .
@@ -16,16 +24,19 @@ build: ts-compile generate-video
 	$(GOCMD) -o ./$(BINDIR)/xteve-status ./cmd/xteve-status
 	@echo "--- Build complete ---"
 
-ts-compile:
+$(JS_DIR): $(TS_SRC)
 	@echo "--- Compiling TypeScript ---"
+	@mkdir -p $(JS_DIR)
 	(npm install && cd ts && npx tsc)
+	@touch $(JS_DIR)
 
-generate-video:
+$(VIDEO_TARGET): $(VIDEO_SRC)
 	@echo "--- Generating video asset ---"
+	@mkdir -p src/html/video
 	@bash build/generate_video.sh
 
 # Test and lint targets
-test: ts-compile generate-video
+test: $(JS_DIR) $(VIDEO_TARGET)
 	@echo "--- Running Go tests ---"
 	$(GO) test ./...
 
@@ -59,7 +70,7 @@ snap: build
 clean:
 	@echo "--- Cleaning up ---"
 	@rm -rf $(BINDIR)
-	@rm -f src/html/video/stream-limit.bin
-	# Add other clean up commands if needed for TypeScript files
+	@rm -f $(VIDEO_TARGET)
+	@rm -rf $(JS_DIR)
 
-.PHONY: all build ts-compile generate-video test lint e2e-test format-check snap clean
+.PHONY: all build test lint e2e-test format-check snap clean


### PR DESCRIPTION
This change modifies the Makefile to make the JavaScript and video builds incremental.

The JavaScript compilation and video generation steps are now defined as Makefile targets. This ensures that they are only executed when their respective source files have changed, which speeds up the build process.

The `ts-compile` target has been replaced with a target that uses the output directory as a stamp file. This is a common pattern for handling directory-based outputs in Makefiles.

The `generate-video` target has been replaced with a target that directly depends on the source image.

The `clean` and `.PHONY` targets have been updated to reflect these changes.