### PR TITLE
Fix path traversal vulnerability in development mode web handler

### DIFF
--- a/src/webserver.go
+++ b/src/webserver.go
@@ -1054,6 +1054,12 @@ func Web(w http.ResponseWriter, r *http.Request) {
 		requestFile = file
 	}
 
+	// Security: Prevent path traversal in dev mode or embedded FS
+	if strings.Contains(requestFile, "..") {
+		httpStatusError(w, r, http.StatusBadRequest)
+		return
+	}
+
 	if System.Dev {
 		contentBytes, err = os.ReadFile("src/" + requestFile)
 		if err != nil {


### PR DESCRIPTION
Fixed a path traversal vulnerability in `src/webserver.go` where `requestFile` was unsafely concatenated into `os.ReadFile` when `System.Dev` was enabled. Added a check using `strings.Contains(requestFile, "..")` to reject malicious requests and return a 400 Bad Request HTTP status code.

---
*PR created automatically by Jules for task [18176557227234460106](https://jules.google.com/task/18176557227234460106) started by @ted-gould*