### PR TITLE
⚡ Bolt: Optimize HTTP routing prefix stripping for zero allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,6 @@
 ## 2024-04-04 - [Single-Pass String Operations]
 **Learning:** In performance-critical paths (like XEPG channel mapping), chaining standard library string operations (e.g., `strings.ToLower(strings.ReplaceAll(...))`) causes unnecessary intermediate string allocations.
 **Action:** Use single-pass helper functions with `strings.Builder` (like `toLowerReplaceSpace`) or allocation-free comparison functions (like `equalFoldNoSpaces`) for string manipulation in hot loops.
+## 2024-04-18 - Avoid strings.Replace for Prefix Stripping in HTTP Handlers
+**Learning:** In Go, using `strings.Replace(url, prefix, "", 1)` to strip a prefix path in HTTP routing (like removing `/stream/` from a `RequestURI`) unnecessarily allocates a new string.
+**Action:** Always use `strings.TrimPrefix(url, prefix)` which returns a sub-slice of the original string (O(1) with 0 allocations), significantly reducing garbage collection pressure on hot paths like stream routers.

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -281,7 +281,8 @@ func Index(w http.ResponseWriter, r *http.Request) {
 
 // Stream : Web Server /stream/
 func Stream(w http.ResponseWriter, r *http.Request) {
-	var path = strings.Replace(r.RequestURI, "/stream/", "", 1)
+	// Optimization: Use strings.TrimPrefix to avoid unnecessary string allocations during routing.
+	var path = strings.TrimPrefix(r.RequestURI, "/stream/")
 	//var stream = strings.SplitN(path, "-", 2)
 
 	streamInfo, err := getStreamInfo(path)
@@ -339,7 +340,8 @@ func Stream(w http.ResponseWriter, r *http.Request) {
 
 // Auto : HDHR routing (is currently not used)
 func Auto(w http.ResponseWriter, r *http.Request) {
-	var channelID = strings.Replace(r.RequestURI, "/auto/v", "", 1)
+	// Optimization: Use strings.TrimPrefix to avoid unnecessary string allocations during routing.
+	var channelID = strings.TrimPrefix(r.RequestURI, "/auto/v")
 	_ = channelID
 
 	/*


### PR DESCRIPTION
💡 What: Replaced `strings.Replace(r.RequestURI, prefix, "", 1)` with `strings.TrimPrefix(r.RequestURI, prefix)` in HTTP routing logic (`Stream` and `Auto` endpoints).

🎯 Why: `strings.Replace` creates a newly allocated string on the heap to perform its replacement. For simple prefix stripping on a hot routing path (every `/stream/` request), this creates unnecessary garbage collection pressure. `strings.TrimPrefix` safely returns a slice of the original string in O(1) time with 0 allocations.

📊 Impact: Reduces memory allocations from 1 to 0 for every stream routing request hit in these handlers. Improves routing throughput on hot paths.

🔬 Measurement: A micro-benchmark of both approaches verifies the exact memory difference per operation. Run standard testing suite (verified with `go test ./...`) to ensure routing correctly strips the necessary strings.

---
*PR created automatically by Jules for task [15589370295855678426](https://jules.google.com/task/15589370295855678426) started by @ted-gould*