### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in template parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -33,3 +33,7 @@
 **Vulnerability:** The API handler restricted access to `localhost` (`r.RemoteAddr`), assuming this provided security. However, when deployed behind a reverse proxy (common for xTeVe), all requests appear to come from `127.0.0.1`. If `Settings.AuthenticationAPI` was disabled (default), external attackers could bypass authentication by proxying through Nginx/Apache, as the application perceived them as local users.
 **Learning:** `r.RemoteAddr` is unreliable for access control when reverse proxies are involved. Relying on "localhost" checks for security is dangerous in modern deployment environments.
 **Prevention:** Authentication logic must take precedence over network location checks. If the application has a "Web Authentication" setting, it should enforce authentication on ALL sensitive endpoints (like API), regardless of the source IP, unless explicitly configured otherwise with full awareness of proxy risks.
+## 2024-05-24 - [Template Injection XSS Prevention]
+**Vulnerability:** Found `text/template` being used in `parseTemplate` instead of `html/template`. This poses an XSS risk since `text/template` doesn't automatically escape context.
+**Learning:** In Go, rendering HTML with `text/template` leaves applications vulnerable to Cross-Site Scripting (XSS).
+**Prevention:** Always use `html/template` when rendering content that is returned to the client as HTML or JavaScript to ensure proper contextual escaping.

--- a/src/toolchain.go
+++ b/src/toolchain.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
-	"text/template"
+	"html/template"
 
 	"github.com/avfs/avfs"
 )


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Template Injection / Cross-Site Scripting (XSS). The `parseTemplate` function used `text/template` instead of `html/template`.
🎯 Impact: Attackers could potentially inject malicious JavaScript if user-controlled variables are rendered through these templates, as `text/template` does not perform contextual auto-escaping.
🔧 Fix: Updated the import to use `html/template`, which automatically escapes variables based on their context (HTML, JS, CSS, URI) during execution.
✅ Verification: Ran unit tests to verify the template parses and executes correctly without breaking existing functionality. Verified code manually.

---
*PR created automatically by Jules for task [3561745544269979099](https://jules.google.com/task/3561745544269979099) started by @ted-gould*